### PR TITLE
Create a unique URL for each npc. Fixes #20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9056,6 +9056,11 @@
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
+    "jsoncrush": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsoncrush/-/jsoncrush-0.1.0.tgz",
+      "integrity": "sha512-22kvyEQorPGJIBnqjOsBkf82EuxCTzCWb3CjbxCeqHXcthU3D5Vv6pDSmtgYZ9Whk03L8nGon+nomjKyi6YJPA=="
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "private": true,
   "dependencies": {
+    "jsoncrush": "^0.1.0",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-scripts": "git+https://github.com/Cellule/dnd-generator-react-scripts.git",

--- a/src/DisplayNpc.tsx
+++ b/src/DisplayNpc.tsx
@@ -1,3 +1,4 @@
+import { JSONUncrush } from 'jsoncrush';
 import React, { Component } from 'react';
 import { Col, Row } from "react-bootstrap";
 import Footer from "./Footer";
@@ -15,10 +16,29 @@ interface IState {
 export default class DisplayNpc extends Component<{}, IState> {
   constructor(props: any) {
     super(props);
-    // Generate initial npc
-    const { npc, debugNode } = generate({});
-    printDebugGen(debugNode);
-    this.state = { npc };
+
+    // Check url query for npc data
+    let loadedQueryData = false;
+    const url = new URL(window.location.href);
+    if (url.searchParams.has('d')) {
+      try {
+        const crushedJson = url.searchParams.get('d') || '';
+        const npc = JSON.parse(JSONUncrush(decodeURIComponent(crushedJson)));
+        this.state = { npc };
+        loadedQueryData = true;
+      } catch (e) {
+        console.error(e);
+        loadedQueryData = false;
+      }
+    }
+
+    // Generate initial npc, if we didn't load data from url query
+    if (!loadedQueryData) {
+      const { npc, debugNode } = generate({});
+      printDebugGen(debugNode);
+      this.state = { npc };
+    }
+
     this.generateNpc = this.generateNpc.bind(this);
   }
 

--- a/src/UserInput.tsx
+++ b/src/UserInput.tsx
@@ -1,3 +1,4 @@
+import { JSONCrush } from 'jsoncrush';
 import {
   Panel,
   Col,
@@ -213,6 +214,9 @@ export default class UserInput extends Component<IProps, IState> {
       );
     });
 
+    const npcDataUrl = new URL(window.location.href);
+    npcDataUrl.searchParams.set('d', JSONCrush(JSON.stringify(this.props.npc)));
+
     return (
       <div>
         <Panel className="hidden-panel">
@@ -227,6 +231,10 @@ export default class UserInput extends Component<IProps, IState> {
             <form onSubmit={this._downloadTxtFile.bind(this)}>
               <Button type="submit" className="center-block download-button download-button" bsStyle="success" />
             </form>
+
+            <a className="center-block npc-link" href={npcDataUrl.toString()}>
+              🔗 Bookmark
+            </a>
           </Panel.Body>
         </Panel>
       </div>

--- a/src/styles/custom-other.less
+++ b/src/styles/custom-other.less
@@ -110,3 +110,16 @@
   background-image: url("../images/export-btn-3.png");
   .box-shadow(none);
 }
+
+.npc-link {
+  margin-top: 30px;
+  font-size: 16px;
+  text-align: center;
+  color: #6f6d6c;
+}
+
+.npc-link:hover,
+.npc-link:focus {
+  text-decoration: none;
+  color: white;
+}


### PR DESCRIPTION
I've often wanted to save generated NPC's for later recall by having a unique URL for them.

This PR adds a "Bookmark" link underneath the EXPORT button:
![image](https://user-images.githubusercontent.com/1897006/84601688-ff205f00-ae36-11ea-98ed-06c2f0b2f4c0.png)

This link is an href that takes the `npc` data and encodes it into the URL using JSONCrush.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cellule/dndgenerator/32)
<!-- Reviewable:end -->
