### PR TITLE
Fix missing space in specialphysical1.json

### DIFF
--- a/src/npcData/tables/specialphysical1.json
+++ b/src/npcData/tables/specialphysical1.json
@@ -2,7 +2,7 @@
   { "w": 4, "v": "{$sphy1+has }{size}{$sphy1+$size}{$sphy1+scar on }{$sphy1+$minPoss}{bodypart}{$sphy1+$bp}" },
   {
     "w": 1,
-    "v": "{$sphy1+has }{size}{$sphy1+$size}{$sphy1+scar on }{$sphy1+$minPoss}{bodypart}{$sphy1+$bp}{$sphy1+and }{size}{$sphy1+$size}{$sphy1+scar on }{$sphy1+$minPoss}{bodypart}{$sphy1+$bp}"
+    "v": "{$sphy1+has }{size}{$sphy1+$size}{$sphy1+scar on }{$sphy1+$minPoss}{bodypart}{$sphy1+$bp}{$sphy1+ and }{size}{$sphy1+$size}{$sphy1+scar on }{$sphy1+$minPoss}{bodypart}{$sphy1+$bp}"
   },
   { "w": 4, "v": "{$sphy1+has }{atattooadj}{$sphy1+$tadj}{$sphy1+piercing on }{$sphy1+$minPoss}{head}{$sphy1+$bp}" },
   {


### PR DESCRIPTION
I was looking at a video reviewing the site and I noticed a missing space
![image](https://user-images.githubusercontent.com/4157103/197305258-816e006b-545d-4711-9da6-de74c2fc21e9.png)

after remembering how the formatting worked, I noticed that `{bodypart}` or more precisely `$bp` doesn't end with a space so we have to add it manually.
I reviewed other usage of `$bp` and it looks good

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cellule/dndgenerator/87)
<!-- Reviewable:end -->
